### PR TITLE
Scrape credits

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,9 @@ class ApplicationController < Sinatra::Base
   end
 
   post '/' do
-    scraper = Scraper.new(params[:url])
+    recurse = true
+    recurse = false if params[:recurse].nil?
+    scraper = Scraper.new(params[:url], recurse)
     scraper.run
     erb :'index.html'
   end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -24,11 +24,8 @@ class Image
     ImageParser.image_entities(@original_url)
   end
 
-  def author
-    # use nameable here
-  end
-
-  def license
-    # get the rest of the credit i guess?
+  def scrape_credit(credit)
+    @credit = credit.partition('Credit').last.tr(':', '').strip
+    @credit = credit.partition('Photo').last.tr(':', '').strip if @credit.empty?
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,9 +1,11 @@
 class Image
   attr_accessor(:original_url) # String, original URL of image
-  attr_accessor(:credit, :license) # Strings
+  attr_accessor(:credit, :flagged)
 
   def initialize(original_url)
     @original_url = original_url
+    @credit = ''
+    @flagged = false
   end
 
   # returns Hash of matching pages and their original pub date

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,6 +1,6 @@
 class Image
   attr_accessor(:original_url) # String, original URL of image
-  attr_accessor(:author, :license) # Strings
+  attr_accessor(:credit, :license) # Strings
 
   def initialize(original_url)
     @original_url = original_url
@@ -20,5 +20,13 @@ class Image
 
   def entities
     ImageParser.image_entities(@original_url)
+  end
+
+  def author
+    # use nameable here
+  end
+
+  def license
+    # get the rest of the credit i guess?
   end
 end

--- a/app/views/index.html.erb
+++ b/app/views/index.html.erb
@@ -2,5 +2,7 @@ hey boiyeeee!
 
 <form action="/" method="post" accept-charset="utf-8">
   <input type="text" name="url" value=""><br>
+  <input type="checkbox" name="recurse" value="">
+  <label for="recurse">Check entire site?</label><br>
   <input class="btn btn-info" type="submit" value="Scrape">
 </form>

--- a/scripts/scraper.rb
+++ b/scripts/scraper.rb
@@ -7,9 +7,10 @@ class Scraper
   attr_accessor(:url, :search_entire_site)
 
   def initialize(url, recurse)
-    @url = URI(url).to_s
     @search_entire_site = recurse
-    @url = 'http://' + @url unless url.is_a?(URI::HTTP) || url.is_a?(URI::HTTPS)
+    uri = URI(url)
+    @url = uri.to_s
+    @url = 'http://' + @url unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
     @main_page = Nokogiri::HTML(open(@url))
     @urls = [URI(@url)]
   end


### PR DESCRIPTION
Scrapes credits from `figcaptions` and creates `Image` instances with the image's URL, the credit, and if it's flagged for a missing caption.

Also adds the option to search a single page rather than the entire site.